### PR TITLE
Skip constructor

### DIFF
--- a/DataBusSerialization/SampleEndpoint/Program.cs
+++ b/DataBusSerialization/SampleEndpoint/Program.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Threading.Tasks;
     using Messages;
+    using Newtonsoft.Json;
     using NServiceBus;
-    using NServiceBus.ObjectBuilder;
 
     class Program
     {
@@ -14,7 +14,12 @@
             const string dataBusPath = @"C:\Temp\DataBus";
 
             var config = new EndpointConfiguration("SampleEndpoint");
-            config.UseSerialization<NewtonsoftSerializer>();
+            var serialization = config.UseSerialization<NewtonsoftSerializer>();
+            serialization.Settings(new JsonSerializerSettings
+            {
+                ContractResolver = new SkipConstructorContractResolver(),
+                TypeNameHandling = TypeNameHandling.Auto
+            });
             config.UseTransport<RabbitMQTransport>()
                 .UseDirectRoutingTopology()
                 .ConnectionString(connectionString);

--- a/DataBusSerialization/SampleEndpoint/SampleEndpoint.csproj
+++ b/DataBusSerialization/SampleEndpoint/SampleEndpoint.csproj
@@ -73,6 +73,7 @@
     <Compile Include="EventHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SkipConstructorContractResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/DataBusSerialization/SampleEndpoint/SkipConstructorContractResolver.cs
+++ b/DataBusSerialization/SampleEndpoint/SkipConstructorContractResolver.cs
@@ -1,0 +1,17 @@
+﻿namespace SampleEndpoint
+{
+    using System;
+    using System.Runtime.Serialization;
+    using Newtonsoft.Json.Serialization;
+
+    class SkipConstructorContractResolver : DefaultContractResolver
+    {
+        protected override JsonObjectContract CreateObjectContract(Type objectType)
+        {
+            var jsonContract = base.CreateObjectContract(objectType);
+            jsonContract.DefaultCreator = () => FormatterServices.GetUninitializedObject(objectType);
+            return jsonContract;
+        }
+
+    }
+}


### PR DESCRIPTION
Instructs the Newtonsoft serializer to skip the constructor on message types.