### PR TITLE
Case 86015: Repro With Interface member

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/NSB.Extensions.Tests/EnclosedMessageTypesMapperTest.cs
+++ b/src/NSB.Extensions.Tests/EnclosedMessageTypesMapperTest.cs
@@ -39,4 +39,19 @@ public class EnclosedMessageTypesMapperTest
 
         result.Should().Be("Company.Product.Contracts.OtherThingHappened, Company.Product.Contracts, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null");
     }
+
+    [Fact]
+    public void AddMany_MapsAllListed()
+    {
+        var input = "Company.Product.Contracts.ThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null";
+        var typeMappings = new Dictionary<string, string>
+        {{
+            "Company.Product.Contracts.ThingHappened",
+            "Company.Product.Contracts.OtherThingHappened, Company.Product.Contracts, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null"
+        }}.ToImmutableDictionary();
+
+        var result = EnclosedMessageTypesMapper.Transform(input, typeMappings);
+
+        result.Should().Be("Company.Product.Contracts.OtherThingHappened, Company.Product.Contracts, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null");
+    }
 }

--- a/src/NSB.Extensions.Tests/EnclosedMessageTypesMapperTest.cs
+++ b/src/NSB.Extensions.Tests/EnclosedMessageTypesMapperTest.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using JetBrains.Annotations;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace NSB.Extensions.Tests;
+
+[TestSubject(typeof(EnclosedMessageTypesMapper))]
+public class EnclosedMessageTypesMapperTest
+{
+
+    [Fact]
+    public void NewAssemblyVersion_MapsToConcreteType()
+    {
+        var input = "Company.Product.Contracts.ThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null";
+        var typeMappings = new Dictionary<string, string>
+        {{
+            "Company.Product.Contracts.ThingHappened",
+            "Company.Product.Contracts.ThingHappened, Company.Product.Contracts, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null"
+        }}.ToImmutableDictionary();
+
+        var result = EnclosedMessageTypesMapper.Transform(input, typeMappings);
+
+        result.Should().Be("Company.Product.Contracts.ThingHappened, Company.Product.Contracts, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null");
+    }
+
+    [Fact]
+    public void TotalTypeReplacement_MapsTargetType()
+    {
+        var input = "Company.Product.Contracts.ThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null";
+        var typeMappings = new Dictionary<string, string>
+        {{
+            "Company.Product.Contracts.ThingHappened",
+            "Company.Product.Contracts.OtherThingHappened, Company.Product.Contracts, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null"
+        }}.ToImmutableDictionary();
+
+        var result = EnclosedMessageTypesMapper.Transform(input, typeMappings);
+
+        result.Should().Be("Company.Product.Contracts.OtherThingHappened, Company.Product.Contracts, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null;Company.Product.Contracts.IThingHappened, Company.Product.Contracts, Version=1.3.79.0, Culture=neutral, PublicKeyToken=null");
+    }
+}

--- a/src/NSB.Extensions.Tests/NSB.Extensions.Tests.csproj
+++ b/src/NSB.Extensions.Tests/NSB.Extensions.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NSB.Extensions\NSB.Extensions.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/src/NSB.Extensions/EnclosedMessageTypesMappingBehavior.cs
+++ b/src/NSB.Extensions/EnclosedMessageTypesMappingBehavior.cs
@@ -1,0 +1,132 @@
+﻿using NServiceBus.Configuration.AdvancedExtensibility;
+using NServiceBus.Features;
+using NServiceBus.Pipeline;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+
+namespace NSB.Extensions
+{
+    public class EnclosedMessageTypesMapper
+    {
+        public static string Transform(string enclosedMessageTypes, ImmutableDictionary<string, string> typeReplacementMappings)
+        {
+            var messageTypes = enclosedMessageTypes.Split(';');
+            for (var i = 0; i < messageTypes.Length; i++)
+            {
+                var messageType = ConvertAssemblyQualifiedNameToTypeFullName(messageTypes[i]);
+                if (typeReplacementMappings.TryGetValue(messageType, out var fixedType))
+                {
+                    messageTypes[i] = fixedType;
+                }
+            }
+
+            return string.Join(";", messageTypes);
+        }
+
+        private static string ConvertAssemblyQualifiedNameToTypeFullName(string typeAssemblyQualifiedName)
+        {
+            return typeAssemblyQualifiedName.Split(',')[0];
+        }
+    }
+
+    /// <summary>
+    /// Configure using <see cref="EnclosedMessageTypesMappingConfigurationExtensions.MapEnclosedMessageTypes"/> 
+    /// </summary>
+    public class EnclosedMessageTypesMappingBehavior : Behavior<IIncomingPhysicalMessageContext>
+    {
+        readonly ImmutableDictionary<string, string> _typeReplacementMappings;
+        readonly ConcurrentDictionary<string, string> _transformedEnclosedMessageTypes = new();
+
+        /// <summary>
+        /// Allow specification of types from the NServiceBus.EnclosedMessageTypes header that should be replaced with
+        /// another type or the same type, but with the Assembly version info ignored.
+        /// </summary>
+        /// <param name="typeReplacementMappings">Supplies a mapping of type FullName to AssemblyQualifiedName. The FullName is
+        /// matched against the types specified in the NServiceBus.EnclosedMessageTypes message header.  If a match is found it
+        /// is replaced with the corresponding value provided. </param>
+        public EnclosedMessageTypesMappingBehavior(ImmutableDictionary<string, string> typeReplacementMappings)
+        {
+            this._typeReplacementMappings = typeReplacementMappings;
+        }
+
+        public override Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
+        {
+            if (!context.Message.Headers.TryGetValue(Headers.EnclosedMessageTypes, out var enclosedMessageTypes))
+            {
+                return next();
+            }
+
+            var transformedHeader = _transformedEnclosedMessageTypes.GetOrAdd(
+                enclosedMessageTypes, EnclosedMessageTypesMapper.Transform,
+                _typeReplacementMappings);
+
+            context.Message.Headers[Headers.EnclosedMessageTypes] = transformedHeader;
+            return next();
+        }
+    }
+
+    /// <summary>
+    /// Allow specification of types from the NServiceBus.EnclosedMessageTypes header that should be replaced with
+    /// another type or the same type, but with the Assembly version info ignored.  Configured using <see cref="EnclosedMessageTypesMappingConfiguration"/>.
+    /// Configure using <see cref="EnclosedMessageTypesMappingConfigurationExtensions.MapEnclosedMessageTypes"/> 
+    /// </summary>
+    public class EnclosedMessageTypesMappingFeature : Feature
+    {
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            var config = context.Settings.Get<EnclosedMessageTypesMappingConfiguration>();
+            context.Pipeline.Register(
+                new EnclosedMessageTypesMappingBehavior(config.Types.ToImmutableDictionary()),
+                "Fixes enclosed message types header for types which have moved"
+            );
+        }
+    }
+
+    /// <summary>
+    /// Configuration of the <see cref="EnclosedMessageTypesMappingFeature"/>
+    /// using <see cref="EnclosedMessageTypesMappingConfigurationExtensions.MapEnclosedMessageTypes"/> 
+    /// </summary>
+    public class EnclosedMessageTypesMappingConfiguration
+    {
+        internal readonly Dictionary<string, string> Types = [];
+
+        /// <summary>
+        /// Ignore Assembly version info for the specified type.
+        /// </summary>
+        /// <param name="type"></param>
+        /// <exception cref="Exception"></exception>
+        public void Add(Type type) => Types.Add(
+            type.FullName ?? throw new Exception($"{type.Name} does not have a valid FullName"),
+            type.AssemblyQualifiedName ?? throw new Exception($"{type.Name} does not have a valid AssemblyQualifiedName")
+        );
+
+        /// <summary>
+        /// Perform a complete type replacement.
+        /// </summary>
+        /// <param name="mapFrom">The source type</param>
+        /// <param name="mapTo">The target type</param>
+        /// <exception cref="Exception">For invalid types</exception>
+        public void Add(Type mapFrom, Type mapTo) => Types.Add(
+            mapFrom.FullName ?? throw new Exception($"{mapFrom.Name} does not have a valid FullName"),
+            mapTo.AssemblyQualifiedName ?? throw new Exception($"{mapTo.Name} does not have a valid AssemblyQualifiedName")
+        );
+    }
+
+    public static class EnclosedMessageTypesMappingConfigurationExtensions
+    {
+        /// <summary>
+        /// Allow specification of types from the NServiceBus.EnclosedMessageTypes header that should be replaced with
+        /// another type or the same type, but with the Assembly version info ignored. 
+        /// </summary>
+        /// <param name="endpointConfiguration"></param>
+        /// <returns><see cref="EnclosedMessageTypesMappingConfiguration"/>: Add types that should be affected by this behavior.
+        /// Either ignoring the Assembly version info of the type or performing a complete type substitution.</returns>
+        public static EnclosedMessageTypesMappingConfiguration MapEnclosedMessageTypes(
+            this EndpointConfiguration endpointConfiguration
+        )
+        {
+            endpointConfiguration.EnableFeature<EnclosedMessageTypesMappingFeature>();
+            return endpointConfiguration.GetSettings().GetOrCreate<EnclosedMessageTypesMappingConfiguration>();
+        }
+    }
+}

--- a/src/NSB.Extensions/EnclosedMessageTypesMappingBehavior.cs
+++ b/src/NSB.Extensions/EnclosedMessageTypesMappingBehavior.cs
@@ -95,10 +95,7 @@ namespace NSB.Extensions
         /// </summary>
         /// <param name="type"></param>
         /// <exception cref="Exception"></exception>
-        public void Add(Type type) => Types.Add(
-            type.FullName ?? throw new Exception($"{type.Name} does not have a valid FullName"),
-            type.AssemblyQualifiedName ?? throw new Exception($"{type.Name} does not have a valid AssemblyQualifiedName")
-        );
+        public void Add(Type type) => Add(type, type);
 
         /// <summary>
         /// Perform a complete type replacement.
@@ -108,8 +105,18 @@ namespace NSB.Extensions
         /// <exception cref="Exception">For invalid types</exception>
         public void Add(Type mapFrom, Type mapTo) => Types.Add(
             mapFrom.FullName ?? throw new Exception($"{mapFrom.Name} does not have a valid FullName"),
-            mapTo.AssemblyQualifiedName ?? throw new Exception($"{mapTo.Name} does not have a valid AssemblyQualifiedName")
+            mapTo.AssemblyQualifiedName ??
+            throw new Exception($"{mapTo.Name} does not have a valid AssemblyQualifiedName")
         );
+
+
+        public void AddMany(IEnumerable<Type> assemblyTypes)
+        {
+            foreach (var type in assemblyTypes)
+            {
+                Add(type);
+            }
+        }
     }
 
     public static class EnclosedMessageTypesMappingConfigurationExtensions

--- a/src/NSB.Extensions/NSB.Extensions.csproj
+++ b/src/NSB.Extensions/NSB.Extensions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="NServiceBus" Version="8.*" />
+	</ItemGroup>
+</Project>

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -1,4 +1,5 @@
 using Contracts;
+using NSB.Extensions;
 using NServiceBus;
 using System;
 
@@ -10,6 +11,7 @@ endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
 endpointConfiguration.Conventions().DefiningEventsAs(t =>
     t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
+endpointConfiguration.MapEnclosedMessageTypes().Add(typeof(SomethingMoreHappened));
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -1,6 +1,6 @@
-using System;
 using Contracts;
 using NServiceBus;
+using System;
 
 var endpointName = "Publisher";
 Console.Title = endpointName;
@@ -14,6 +14,8 @@ var endpointInstance = await Endpoint.Start(endpointConfiguration);
 Console.WriteLine("Press enter to publish a message");
 Console.WriteLine("Press any key to exit");
 
+int i = 0;
+
 while (true)
 {
     var key = Console.ReadKey();
@@ -23,13 +25,29 @@ while (true)
         break;
     }
 
-    await endpointInstance.Publish<ISomethingMoreHappened>(sh =>
+    /*if (i % 2 == 0)
     {
-        sh.SomeData = 1;
-        sh.MoreInfo = "It's a secret.";
+        await endpointInstance.Publish<ISomethingMoreHappened>(sh =>
+        {
+            sh.SomeData = 1;
+            sh.MoreInfo = "It's a secret.";
+            sh.Child = new ComplexChild();
+        });
+    }
+    else
+    {
+
+    }*/
+
+    await endpointInstance.Publish(new SomethingMoreHappened
+    {
+        SomeData = 1,
+        MoreInfo = "It's a secret.",
+        Child = new ComplexChild(),
     });
 
     Console.WriteLine("Published event.");
+    i++;
 }
 
 await endpointInstance.Stop();

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -8,6 +8,8 @@ Console.Title = endpointName;
 var endpointConfiguration = new EndpointConfiguration(endpointName);
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
+endpointConfiguration.Conventions().DefiningEventsAs(t =>
+    t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/src/Publisher/Program.cs
+++ b/src/Publisher/Program.cs
@@ -1,0 +1,35 @@
+using System;
+using Contracts;
+using NServiceBus;
+
+var endpointName = "Publisher";
+Console.Title = endpointName;
+
+var endpointConfiguration = new EndpointConfiguration(endpointName);
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UseTransport(new LearningTransport());
+
+var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+Console.WriteLine("Press enter to publish a message");
+Console.WriteLine("Press any key to exit");
+
+while (true)
+{
+    var key = Console.ReadKey();
+
+    if (key.Key != ConsoleKey.Enter)
+    {
+        break;
+    }
+
+    await endpointInstance.Publish<ISomethingMoreHappened>(sh =>
+    {
+        sh.SomeData = 1;
+        sh.MoreInfo = "It's a secret.";
+    });
+
+    Console.WriteLine("Published event.");
+}
+
+await endpointInstance.Stop();

--- a/src/Publisher/Publisher.csproj
+++ b/src/Publisher/Publisher.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Publisher/Publisher.csproj
+++ b/src/Publisher/Publisher.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
+    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/Publisher/Publisher.csproj
+++ b/src/Publisher/Publisher.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NSB.Extensions\NSB.Extensions.csproj" />
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
     <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>

--- a/src/V1.Contracts/Contracts.csproj
+++ b/src/V1.Contracts/Contracts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/src/V1.Contracts/Contracts.csproj
+++ b/src/V1.Contracts/Contracts.csproj
@@ -5,6 +5,5 @@
     <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/V1.Contracts/ISomethingHappened.cs
+++ b/src/V1.Contracts/ISomethingHappened.cs
@@ -1,10 +1,8 @@
 ﻿namespace Contracts
 {
-    using NServiceBus;
-
     #region V1Message
 
-    public interface ISomethingHappened : IEvent
+    public interface ISomethingHappened
     {
         int SomeData { get; set; }
 

--- a/src/V1.Contracts/ISomethingHappened.cs
+++ b/src/V1.Contracts/ISomethingHappened.cs
@@ -7,7 +7,28 @@
     public interface ISomethingHappened : IEvent
     {
         int SomeData { get; set; }
+
+        IComplexChild Child { get; }
     }
+
+    public interface IComplexChild
+    {
+        bool IsComplex { get; }
+    }
+
+    public class ComplexChild : IComplexChild
+    {
+        public bool IsComplex => true;
+    }
+
+    public class SomethingMoreHappened : ISomethingHappened
+    {
+        public int SomeData { get; set; }
+        public ComplexChild Child { get; set; } = new ComplexChild();
+
+        IComplexChild ISomethingHappened.Child => Child;
+    }
+
 
     #endregion
 }

--- a/src/V1.Contracts/ISomethingHappened.cs
+++ b/src/V1.Contracts/ISomethingHappened.cs
@@ -1,0 +1,13 @@
+﻿namespace Contracts
+{
+    using NServiceBus;
+
+    #region V1Message
+
+    public interface ISomethingHappened : IEvent
+    {
+        int SomeData { get; set; }
+    }
+
+    #endregion
+}

--- a/src/V1.Subscriber/Program.cs
+++ b/src/V1.Subscriber/Program.cs
@@ -1,5 +1,5 @@
-using System;
 using NServiceBus;
+using System;
 
 var endpointName = "V1.Subscriber";
 Console.Title = endpointName;
@@ -7,6 +7,8 @@ Console.Title = endpointName;
 var endpointConfiguration = new EndpointConfiguration(endpointName);
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
+endpointConfiguration.Conventions().DefiningMessagesAs(t =>
+    t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/src/V1.Subscriber/Program.cs
+++ b/src/V1.Subscriber/Program.cs
@@ -1,3 +1,5 @@
+using Contracts;
+using NSB.Extensions;
 using NServiceBus;
 using System;
 
@@ -9,6 +11,7 @@ endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
 endpointConfiguration.Conventions().DefiningMessagesAs(t =>
     t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
+endpointConfiguration.MapEnclosedMessageTypes().Add(typeof(SomethingMoreHappened));
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/src/V1.Subscriber/Program.cs
+++ b/src/V1.Subscriber/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using NServiceBus;
+
+var endpointName = "V1.Subscriber";
+Console.Title = endpointName;
+
+var endpointConfiguration = new EndpointConfiguration(endpointName);
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UseTransport(new LearningTransport());
+
+var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+Console.WriteLine("Press any key to exit");
+Console.ReadKey();
+
+await endpointInstance.Stop();

--- a/src/V1.Subscriber/SomethingHappenedHandler.cs
+++ b/src/V1.Subscriber/SomethingHappenedHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace V1.Subscriber
+{
+    using System.Threading.Tasks;
+    using Contracts;
+    using NServiceBus;
+    using NServiceBus.Logging;
+
+    public class SomethingHappenedHandler : IHandleMessages<ISomethingHappened>
+    {
+        static readonly ILog log = LogManager.GetLogger<SomethingHappenedHandler>();
+
+        public Task Handle(ISomethingHappened message, IMessageHandlerContext context)
+        {
+            log.Info($"Something happened with some data '{message.SomeData}'");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/V1.Subscriber/V1.Subscriber.csproj
+++ b/src/V1.Subscriber/V1.Subscriber.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V1.Contracts\Contracts.csproj" />
+    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/V1.Subscriber/V1.Subscriber.csproj
+++ b/src/V1.Subscriber/V1.Subscriber.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\V1.Contracts\Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/V1.Subscriber/V1.Subscriber.csproj
+++ b/src/V1.Subscriber/V1.Subscriber.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NSB.Extensions\NSB.Extensions.csproj" />
     <ProjectReference Include="..\V1.Contracts\Contracts.csproj" />
     <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>

--- a/src/V2.Contracts/Contracts.csproj
+++ b/src/V2.Contracts/Contracts.csproj
@@ -5,6 +5,5 @@
     <Version>2.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/V2.Contracts/Contracts.csproj
+++ b/src/V2.Contracts/Contracts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
+    <Version>2.0.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="8.*" />
+  </ItemGroup>
+</Project>

--- a/src/V2.Contracts/ISomethingHappened.cs
+++ b/src/V2.Contracts/ISomethingHappened.cs
@@ -1,0 +1,9 @@
+﻿namespace Contracts
+{
+    using NServiceBus;
+
+    public interface ISomethingHappened : IEvent
+    {
+        int SomeData { get; set; }
+    }
+}

--- a/src/V2.Contracts/ISomethingHappened.cs
+++ b/src/V2.Contracts/ISomethingHappened.cs
@@ -5,5 +5,16 @@
     public interface ISomethingHappened : IEvent
     {
         int SomeData { get; set; }
+        IComplexChild Child { get; }
+    }
+
+    public interface IComplexChild
+    {
+        bool IsComplex { get; }
+    }
+
+    public class ComplexChild : IComplexChild
+    {
+        public bool IsComplex => true;
     }
 }

--- a/src/V2.Contracts/ISomethingHappened.cs
+++ b/src/V2.Contracts/ISomethingHappened.cs
@@ -1,8 +1,7 @@
 ﻿namespace Contracts
 {
-    using NServiceBus;
 
-    public interface ISomethingHappened : IEvent
+    public interface ISomethingHappened
     {
         int SomeData { get; set; }
         IComplexChild Child { get; }

--- a/src/V2.Contracts/ISomethingMoreHappened.cs
+++ b/src/V2.Contracts/ISomethingMoreHappened.cs
@@ -1,0 +1,11 @@
+namespace Contracts
+{
+    #region V2Message
+
+    public interface ISomethingMoreHappened : ISomethingHappened
+    {
+        string MoreInfo { get; set; }
+    }
+
+    #endregion
+}

--- a/src/V2.Contracts/ISomethingMoreHappened.cs
+++ b/src/V2.Contracts/ISomethingMoreHappened.cs
@@ -7,5 +7,15 @@ namespace Contracts
         string MoreInfo { get; set; }
     }
 
+    public class SomethingMoreHappened : ISomethingMoreHappened
+    {
+        public int SomeData { get; set; }
+        public ComplexChild Child { get; set; } = new ComplexChild();
+        public string MoreInfo { get; set; }
+
+
+        IComplexChild ISomethingHappened.Child => Child;
+    }
+
     #endregion
 }

--- a/src/V2.Subscriber/Program.cs
+++ b/src/V2.Subscriber/Program.cs
@@ -1,3 +1,5 @@
+using Contracts;
+using NSB.Extensions;
 using NServiceBus;
 using System;
 
@@ -9,6 +11,7 @@ endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
 endpointConfiguration.Conventions().DefiningMessagesAs(t =>
     t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
+endpointConfiguration.MapEnclosedMessageTypes().Add(typeof(SomethingMoreHappened));
 
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);

--- a/src/V2.Subscriber/Program.cs
+++ b/src/V2.Subscriber/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using NServiceBus;
+
+var endpointName = "V2.Subscriber";
+Console.Title = endpointName;
+
+var endpointConfiguration = new EndpointConfiguration(endpointName);
+endpointConfiguration.UseSerialization<SystemJsonSerializer>();
+endpointConfiguration.UseTransport(new LearningTransport());
+
+var endpointInstance = await Endpoint.Start(endpointConfiguration);
+
+Console.WriteLine("Press any key to exit");
+Console.ReadKey();
+
+await endpointInstance.Stop();

--- a/src/V2.Subscriber/Program.cs
+++ b/src/V2.Subscriber/Program.cs
@@ -1,5 +1,5 @@
-using System;
 using NServiceBus;
+using System;
 
 var endpointName = "V2.Subscriber";
 Console.Title = endpointName;
@@ -7,6 +7,9 @@ Console.Title = endpointName;
 var endpointConfiguration = new EndpointConfiguration(endpointName);
 endpointConfiguration.UseSerialization<SystemJsonSerializer>();
 endpointConfiguration.UseTransport(new LearningTransport());
+endpointConfiguration.Conventions().DefiningMessagesAs(t =>
+    t.Namespace?.Contains("Contracts", StringComparison.InvariantCultureIgnoreCase) == true);
+
 
 var endpointInstance = await Endpoint.Start(endpointConfiguration);
 

--- a/src/V2.Subscriber/SomethingMoreHappenedHandler.cs
+++ b/src/V2.Subscriber/SomethingMoreHappenedHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace V2.Subscriber
+{
+    using System.Threading.Tasks;
+    using Contracts;
+    using NServiceBus;
+    using NServiceBus.Logging;
+
+    public class SomethingMoreHappenedHandler : IHandleMessages<ISomethingMoreHappened>
+    {
+        static readonly ILog log = LogManager.GetLogger<SomethingMoreHappenedHandler>();
+
+        public Task Handle(ISomethingMoreHappened message, IMessageHandlerContext context)
+        {
+            log.Info($"Something happened with some data '{message.SomeData}' and more information '{message.MoreInfo}'");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/V2.Subscriber/V2.Subscriber.csproj
+++ b/src/V2.Subscriber/V2.Subscriber.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/V2.Subscriber/V2.Subscriber.csproj
+++ b/src/V2.Subscriber/V2.Subscriber.csproj
@@ -6,5 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
+    <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>
 </Project>

--- a/src/V2.Subscriber/V2.Subscriber.csproj
+++ b/src/V2.Subscriber/V2.Subscriber.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\NSB.Extensions\NSB.Extensions.csproj" />
     <ProjectReference Include="..\V2.Contracts\Contracts.csproj" />
     <PackageReference Include="NServiceBus" Version="8.*" />
   </ItemGroup>

--- a/src/Versioning.sln
+++ b/src/Versioning.sln
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "V1", "V1", "{4D35CA52-4A3C-
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contracts", "Contracts", "{F5C2DC42-C4D7-4806-A00B-467ED6F017FD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSB.Extensions", "NSB.Extensions\NSB.Extensions.csproj", "{525EFBEC-8C63-4760-9E05-6855EE9D7D7B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSB.Extensions.Tests", "NSB.Extensions.Tests\NSB.Extensions.Tests.csproj", "{5C30B88D-3E22-47EF-91B7-32BA86EA80F8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +48,14 @@ Global
 		{E061B013-0118-4167-A508-C28EC114240E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E061B013-0118-4167-A508-C28EC114240E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E061B013-0118-4167-A508-C28EC114240E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{525EFBEC-8C63-4760-9E05-6855EE9D7D7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{525EFBEC-8C63-4760-9E05-6855EE9D7D7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{525EFBEC-8C63-4760-9E05-6855EE9D7D7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{525EFBEC-8C63-4760-9E05-6855EE9D7D7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C30B88D-3E22-47EF-91B7-32BA86EA80F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C30B88D-3E22-47EF-91B7-32BA86EA80F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C30B88D-3E22-47EF-91B7-32BA86EA80F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C30B88D-3E22-47EF-91B7-32BA86EA80F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Versioning.sln
+++ b/src/Versioning.sln
@@ -1,0 +1,60 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34511.84
+MinimumVisualStudioVersion = 15.0.26730.12
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "V2.Subscriber", "V2.Subscriber\V2.Subscriber.csproj", "{BD68E573-6E04-4332-8CAD-28F70138147B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Publisher", "Publisher\Publisher.csproj", "{8CC1879B-E612-4CC7-9D31-2E2C0A2DE71C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "V1.Subscriber", "V1.Subscriber\V1.Subscriber.csproj", "{176A895F-77F8-4874-B21C-130596C36231}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contracts", "V1.Contracts\Contracts.csproj", "{3FA7348D-59C7-4795-BE0D-0F08373ACC07}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "V2", "V2", "{97820740-52DF-4942-894D-CFB04AFA9AE9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contracts", "V2.Contracts\Contracts.csproj", "{E061B013-0118-4167-A508-C28EC114240E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "V1", "V1", "{4D35CA52-4A3C-4730-8415-F381EE56FC0C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Contracts", "Contracts", "{F5C2DC42-C4D7-4806-A00B-467ED6F017FD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BD68E573-6E04-4332-8CAD-28F70138147B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD68E573-6E04-4332-8CAD-28F70138147B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD68E573-6E04-4332-8CAD-28F70138147B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD68E573-6E04-4332-8CAD-28F70138147B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CC1879B-E612-4CC7-9D31-2E2C0A2DE71C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CC1879B-E612-4CC7-9D31-2E2C0A2DE71C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CC1879B-E612-4CC7-9D31-2E2C0A2DE71C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CC1879B-E612-4CC7-9D31-2E2C0A2DE71C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{176A895F-77F8-4874-B21C-130596C36231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{176A895F-77F8-4874-B21C-130596C36231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{176A895F-77F8-4874-B21C-130596C36231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{176A895F-77F8-4874-B21C-130596C36231}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FA7348D-59C7-4795-BE0D-0F08373ACC07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FA7348D-59C7-4795-BE0D-0F08373ACC07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FA7348D-59C7-4795-BE0D-0F08373ACC07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FA7348D-59C7-4795-BE0D-0F08373ACC07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E061B013-0118-4167-A508-C28EC114240E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E061B013-0118-4167-A508-C28EC114240E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E061B013-0118-4167-A508-C28EC114240E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E061B013-0118-4167-A508-C28EC114240E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3FA7348D-59C7-4795-BE0D-0F08373ACC07} = {4D35CA52-4A3C-4730-8415-F381EE56FC0C}
+		{97820740-52DF-4942-894D-CFB04AFA9AE9} = {F5C2DC42-C4D7-4806-A00B-467ED6F017FD}
+		{E061B013-0118-4167-A508-C28EC114240E} = {97820740-52DF-4942-894D-CFB04AFA9AE9}
+		{4D35CA52-4A3C-4730-8415-F381EE56FC0C} = {F5C2DC42-C4D7-4806-A00B-467ED6F017FD}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DC4E7547-2A6B-414A-9327-9648AF374274}
+	EndGlobalSection
+EndGlobal

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="particular packages" value="https://f.feedz.io/particular-software/packages/nuget/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="particular packages">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="local packages">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
1. Started with a copy of:
https://github.com/Eventellect/docs.particular.net/tree/master/samples/versioning/Core_8

2. [Add Complex Child interface and class](https://github.com/mikeminutillo/SupportRepro/pull/7/commits/40e0cf2b05587fa9026c678b0ebd6dfddd9734c0) - both subscribers are able to consume the event even though it does not match the version
3. [Switched to Unobtrusive mode](https://github.com/mikeminutillo/SupportRepro/pull/7/commits/dfbd054d823756a26f353d3e1b580fca9cd32568) - No other changes.  It no longer works.
> NServiceBus.MessageDeserializationException: An error occurred while attempting to extract logical messages from incoming physical message 9ec5500e-fc24-4922-a255-b12c003c2c0b
> ---> System.NotSupportedException: Deserialization of interface types is not supported. Type 'Contracts.IComplexChild'. Path: $.Child | LineNumber: 0 | BytePositionInLine: 23.
4. [Workaround the behavior change](https://github.com/mikeminutillo/SupportRepro/pull/7/commits/a9bdd6568dff6f861df294f867b4aa897c45f4f6) of unobtrusive messages using `EnclosedMessageTypesMappingBehavior`